### PR TITLE
Refactor theme handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,9 @@
-
-import { useEffect } from "react";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
-import { useTheme, ThemeProvider } from "@/hooks/useTheme";
+import { ThemeProvider } from "@/hooks/useTheme";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 import InstallPrompt from "./components/InstallPrompt";
@@ -14,14 +12,6 @@ const queryClient = new QueryClient();
 
 const AppContent = () => {
   console.log("App component rendering...");
-  
-  const { theme, applyTheme } = useTheme();
-
-  useEffect(() => {
-    console.log("App mounted, applying theme:", theme);
-    // Apply theme on app load
-    applyTheme(theme);
-  }, [theme, applyTheme]);
 
   return (
     <TooltipProvider>

--- a/src/components/ChatBody.tsx
+++ b/src/components/ChatBody.tsx
@@ -33,8 +33,8 @@ interface ChatBodyProps {
 export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
   ({ conversation, isTyping, onQuickAction, onRetryMessage }, ref) => {
     const messagesEndRef = useRef<HTMLDivElement>(null);
-    const { theme } = useTheme();
-    const logoSrc = `/logo-${theme.color}${theme.variant}.png`;
+    const { color, variant } = useTheme();
+    const logoSrc = `/logo-${color}${variant}.png`;
 
     const scrollToBottom = () => {
       messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -27,13 +27,13 @@ export const ChatHeader = ({
   onProfileChange,
   onOpenProfiles
 }: ChatHeaderProps) => {
-  const { theme, updateTheme } = useTheme();
+  const { color, variant, setVariant } = useTheme();
 
   const toggleVariant = () => {
-    updateTheme({ ...theme, variant: theme.variant === 'dark' ? 'light' : 'dark' });
+    setVariant(variant === 'dark' ? 'light' : 'dark');
   };
 
-  const logoSrc = `/logo-${theme.color}${theme.variant}.png`;
+  const logoSrc = `/logo-${color}${variant}.png`;
   return (
     <div className="flex items-center justify-between p-4 border-b border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/60">
       <div className="flex items-center gap-3">

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -12,14 +12,14 @@ import {
 import { useTheme, ThemeColor, ThemeVariant } from "@/hooks/useTheme";
 
 export const ThemeSelector = () => {
-  const { theme, updateTheme } = useTheme();
+  const { color, variant, setColor, setVariant } = useTheme();
 
-  const handleColorChange = (color: ThemeColor) => {
-    updateTheme({ ...theme, color });
+  const handleColorChange = (c: ThemeColor) => {
+    setColor(c);
   };
 
-  const handleVariantChange = (variant: ThemeVariant) => {
-    updateTheme({ ...theme, variant });
+  const handleVariantChange = (v: ThemeVariant) => {
+    setVariant(v);
   };
 
   const themeOptions = [
@@ -40,7 +40,7 @@ export const ThemeSelector = () => {
       {/* Color Selection */}
       <div className="space-y-2">
         <Label className="text-sm">Color Scheme</Label>
-        <Select value={theme.color} onValueChange={handleColorChange}>
+        <Select value={color} onValueChange={handleColorChange}>
           <SelectTrigger>
             <SelectValue placeholder="Choose color scheme" />
           </SelectTrigger>
@@ -66,7 +66,7 @@ export const ThemeSelector = () => {
         <div className="flex gap-2">
           <Button
             type="button"
-            variant={theme.variant === 'dark' ? 'default' : 'outline'}
+            variant={variant === 'dark' ? 'default' : 'outline'}
             size="sm"
             onClick={() => handleVariantChange('dark')}
             className="flex-1"
@@ -76,7 +76,7 @@ export const ThemeSelector = () => {
           </Button>
           <Button
             type="button"
-            variant={theme.variant === 'light' ? 'default' : 'outline'}
+            variant={variant === 'light' ? 'default' : 'outline'}
             size="sm"
             onClick={() => handleVariantChange('light')}
             className="flex-1"
@@ -88,7 +88,7 @@ export const ThemeSelector = () => {
       </div>
 
       <p className="text-sm text-muted-foreground">
-        Current: {themeOptions.find(t => t.value === theme.color)?.label} {theme.variant === 'dark' ? 'Dark' : 'Light'}
+        Current: {themeOptions.find(t => t.value === color)?.label} {variant === 'dark' ? 'Dark' : 'Light'}
       </p>
     </div>
   );

--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -2,89 +2,46 @@
 import {
   useState,
   useEffect,
-  useCallback,
   createContext,
   useContext,
-  ReactNode,
 } from 'react';
 
 export type ThemeVariant = 'dark' | 'light';
 export type ThemeColor = 'default' | 'blue' | 'red' | 'green' | 'purple';
 
-export interface Theme {
+interface ThemeContextValue {
   color: ThemeColor;
   variant: ThemeVariant;
-}
-
-interface ThemeContextValue {
-  theme: Theme;
-  updateTheme: (theme: Theme) => void;
-  applyTheme: (theme: Theme) => void;
+  setColor: (color: ThemeColor) => void;
+  setVariant: (variant: ThemeVariant) => void;
 }
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
 export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
-  const [theme, setTheme] = useState<Theme>({
-    color: 'default',
-    variant: 'dark',
-  });
+  const [color, setColor] = useState<ThemeColor>('default');
+  const [variant, setVariant] = useState<ThemeVariant>('dark');
 
-  const applyTheme = useCallback((newTheme: Theme) => {
-    const { color, variant } = newTheme;
-
-    // Remove all existing theme classes and attributes
-    document.body.classList.remove(
-      'dark-mode', 'light-mode'
-    );
-    document.documentElement.removeAttribute('data-theme');
-    document.documentElement.classList.remove(
-      'theme-default', 'theme-blue', 'theme-red', 'theme-green', 'theme-purple'
-    );
-
-    // Apply new theme
-    const themeAttribute = `${color}-${variant}`;
-    document.documentElement.setAttribute('data-theme', themeAttribute);
-    document.documentElement.classList.add(`theme-${color}`);
-
-    // Also add body class for backward compatibility
-    document.body.classList.add(`${variant}-mode`);
-    
-    console.log('Applied theme:', themeAttribute);
-    
-    // Force a repaint to ensure immediate visual update
-    document.documentElement.style.display = 'none';
-    void document.documentElement.offsetHeight; // Trigger reflow
-    document.documentElement.style.display = '';
+  useEffect(() => {
+    const saved = localStorage.getItem('vivica-theme');
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved) as { color: ThemeColor; variant: ThemeVariant };
+        setColor(parsed.color);
+        setVariant(parsed.variant);
+      } catch {
+        // ignore invalid values
+      }
+    }
   }, []);
 
   useEffect(() => {
-    // Load theme from localStorage on mount
-    const savedTheme = localStorage.getItem('vivica-theme');
-    if (savedTheme) {
-      try {
-        const parsedTheme = JSON.parse(savedTheme);
-        setTheme(parsedTheme);
-        applyTheme(parsedTheme);
-      } catch (error) {
-        console.error('Failed to parse saved theme:', error);
-        // Apply default theme on error
-        applyTheme(theme);
-      }
-    } else {
-      // Apply default theme
-      applyTheme(theme);
-    }
-  }, [applyTheme]);
-
-  const updateTheme = useCallback((newTheme: Theme) => {
-    setTheme(newTheme);
-    applyTheme(newTheme);
-    localStorage.setItem('vivica-theme', JSON.stringify(newTheme));
-  }, [applyTheme]);
+    document.documentElement.setAttribute('data-theme', `${color}-${variant}`);
+    localStorage.setItem('vivica-theme', JSON.stringify({ color, variant }));
+  }, [color, variant]);
 
   return (
-    <ThemeContext.Provider value={{ theme, updateTheme, applyTheme }}>
+    <ThemeContext.Provider value={{ color, variant, setColor, setVariant }}>
       {children}
     </ThemeContext.Provider>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -70,61 +70,8 @@
   }
 }
 
-/* Color Theme Classes - These work together with data-theme attributes */
-.theme-default {
-  --theme-primary: 0 0% 100%;
-  --theme-accent: 0 0% 80%;
-  --accent-primary: var(--theme-primary);
-  --accent-secondary: var(--theme-accent);
-}
-
-.theme-blue {
-  --theme-primary: 210 100% 50%;
-  --theme-accent: 210 100% 60%;
-  --accent-primary: var(--theme-primary);
-  --accent-secondary: var(--theme-accent);
-  /* Override shadcn variables with blue theme */
-  --primary: 210 100% 50%;
-  --accent: 210 100% 50%;
-  --ring: 210 100% 50%;
-}
-
-.theme-red {
-  --theme-primary: 0 84% 60%;
-  --theme-accent: 0 91% 71%;
-  --accent-primary: var(--theme-primary);
-  --accent-secondary: var(--theme-accent);
-  /* Override shadcn variables with red theme */
-  --primary: 0 84% 60%;
-  --accent: 0 84% 60%;
-  --ring: 0 84% 60%;
-}
-
-.theme-green {
-  --theme-primary: 160 84% 39%;
-  --theme-accent: 158 64% 52%;
-  --accent-primary: var(--theme-primary);
-  --accent-secondary: var(--theme-accent);
-  /* Override shadcn variables with green theme */
-  --primary: 160 84% 39%;
-  --accent: 160 84% 39%;
-  --ring: 160 84% 39%;
-}
-
-.theme-purple {
-  --theme-primary: 280 100% 70%;
-  --theme-accent: 285 100% 80%;
-  --accent-primary: var(--theme-primary);
-  --accent-secondary: var(--theme-accent);
-  /* Override shadcn variables with purple theme */
-  --primary: 280 100% 70%;
-  --accent: 280 100% 70%;
-  --ring: 280 100% 70%;
-}
-
 /* DEFAULT DARK THEME - Black */
-[data-theme="default-dark"],
-.dark-mode {
+[data-theme="default-dark"] {
   --bg-primary: 0 0% 0%;
   --bg-secondary: 0 0% 4%;
   --bg-tertiary: 0 0% 7%;
@@ -157,8 +104,7 @@
 }
 
 /* DEFAULT LIGHT THEME - White */
-[data-theme="default-light"],
-.light-mode {
+[data-theme="default-light"] {
   --bg-primary: 0 0% 100%;
   --bg-secondary: 0 0% 96%;
   --bg-tertiary: 0 0% 88%;


### PR DESCRIPTION
## Summary
- simplify theme context to use a single `data-theme` attribute
- adjust header, selector and body components for new hook
- drop old theme classes from styles

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a774ee228832a97559f0de6dd4d74