### PR TITLE
Improve voice mode and RSS widget

### DIFF
--- a/src/components/ChatBody.tsx
+++ b/src/components/ChatBody.tsx
@@ -9,6 +9,25 @@ import { toast } from "sonner";
 import { WeatherWidget } from "@/components/WeatherWidget";
 import { RSSWidget } from "@/components/RSSWidget";
 
+const getUserName = () => {
+  try {
+    const mem = JSON.parse(localStorage.getItem('vivica-memory') || '{}');
+    return mem.identity?.name || 'User';
+  } catch {
+    return 'User';
+  }
+};
+
+const getProfileName = (id?: string) => {
+  try {
+    const list: { id: string; name: string }[] = JSON.parse(localStorage.getItem('vivica-profiles') || '[]');
+    const pid = id || localStorage.getItem('vivica-current-profile');
+    return list.find((p) => p.id === pid)?.name || 'Vivica';
+  } catch {
+    return 'Vivica';
+  }
+};
+
 interface Message {
   id: string;
   content: string;
@@ -93,9 +112,9 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
               >
                 <div className="flex items-start gap-3 max-w-[85%] md:max-w-[70%]">
                   {message.role === 'assistant' && (
-                    <div className="w-8 h-8 rounded-full bg-accent text-accent-foreground flex items-center justify-center text-sm font-semibold flex-shrink-0">
-                      V
-                    </div>
+                    <span className="mt-1 text-xs font-semibold text-accent-foreground">
+                      {getProfileName(message.profileId)}
+                    </span>
                   )}
                   
                   <div className={`message-bubble ${message.role} ${
@@ -143,9 +162,9 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
                   </div>
                   
                   {message.role === 'user' && (
-                    <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center text-sm font-semibold flex-shrink-0">
-                      U
-                    </div>
+                    <span className="mt-1 text-xs font-semibold text-muted-foreground">
+                      {getUserName()}
+                    </span>
                   )}
                 </div>
               </div>
@@ -155,15 +174,15 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
             {isTyping && (
               <div className="flex justify-start slide-up">
                 <div className="flex items-start gap-3">
-                  <div className="w-8 h-8 rounded-full bg-accent text-accent-foreground flex items-center justify-center text-sm font-semibold">
-                    V
-                  </div>
+                  <span className="mt-1 text-xs font-semibold text-accent-foreground">
+                    {getProfileName()}
+                  </span>
                   <div className="message-bubble assistant">
                     <div className="typing-indicator">
                       <div className="typing-dot"></div>
                       <div className="typing-dot"></div>
                       <div className="typing-dot"></div>
-                      <span className="ml-2">Vivica is typing...</span>
+                      <span className="ml-2">{getProfileName()} is typing...</span>
                     </div>
                   </div>
                 </div>

--- a/src/index.css
+++ b/src/index.css
@@ -58,6 +58,9 @@
     --user-bubble-bg: hsl(var(--bg-primary));
     --user-bubble-text: hsl(var(--text-primary));
     --user-bubble-border: 1px solid hsl(var(--accent-primary));
+    --assistant-bubble-bg: hsl(var(--bg-secondary));
+    --assistant-bubble-text: hsl(var(--text-primary));
+    --assistant-bubble-border: 1px solid hsl(var(--border-custom));
     --gradient-primary: linear-gradient(135deg, hsl(var(--bg-primary)) 0%, hsl(var(--bg-hover)) 100%);
     --gradient-accent: linear-gradient(135deg, hsl(var(--theme-primary)) 0%, hsl(var(--theme-accent)) 100%);
     --modal-bg: hsl(var(--bg-secondary));
@@ -669,11 +672,11 @@
 }
 
 .message-bubble.assistant {
-  background: hsl(var(--bg-secondary));
-  color: hsl(var(--text-primary));
+  background: var(--assistant-bubble-bg);
+  color: var(--assistant-bubble-text);
   margin-right: auto;
   border-bottom-left-radius: 6px;
-  border: 1px solid hsl(var(--border-custom));
+  border: var(--assistant-bubble-border);
 }
 
 /* Typing indicator */


### PR DESCRIPTION
## Summary
- connect voice mode to active profile and chat context
- send transcribed voice input to the chat service
- display active profile name in voice overlay
- fetch news articles before sending to the AI
- show sender names in chat bubbles
- add contrasting chat bubble themes
- include weather info when building system prompts

## Testing
- `npm run lint` *(fails: Unexpected any errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6880e591292c832a8a574b602cddf41c