### PR TITLE
Add RSS headlines to prompts and start chat from articles

### DIFF
--- a/src/components/ChatBody.tsx
+++ b/src/components/ChatBody.tsx
@@ -59,10 +59,11 @@ interface ChatBodyProps {
   isTyping: boolean;
   onRetryMessage?: (messageId: string) => void;
   onSendMessage: (content: string) => void;
+  onNewChat: () => void;
 }
 
 export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
-  ({ conversation, isTyping, onRetryMessage, onSendMessage }, ref) => {
+  ({ conversation, isTyping, onRetryMessage, onSendMessage, onNewChat }, ref) => {
     const messagesEndRef = useRef<HTMLDivElement>(null);
     const { color, variant } = useTheme();
     const logoSrc = `/logo-${color}${variant}.png`;
@@ -143,7 +144,7 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
 
             <div className="grid grid-cols-1 gap-4 w-full max-w-md">
               <WeatherWidget />
-              <RSSWidget onSendMessage={onSendMessage} />
+              <RSSWidget onSendMessage={onSendMessage} onNewChat={onNewChat} />
             </div>
           </div>
         ) : (

--- a/src/components/RSSWidget.tsx
+++ b/src/components/RSSWidget.tsx
@@ -48,9 +48,10 @@ async function fetchRSSSummariesWithLinks(urls: string[]): Promise<Headline[]> {
 
 interface RSSWidgetProps {
   onSendMessage: (content: string) => void;
+  onNewChat: () => void;
 }
 
-export const RSSWidget = ({ onSendMessage }: RSSWidgetProps) => {
+export const RSSWidget = ({ onSendMessage, onNewChat }: RSSWidgetProps) => {
   const tickerRef = useRef<HTMLDivElement>(null);
   const [currentHeadline, setCurrentHeadline] = useState<Headline | null>(null);
   const [headlines, setHeadlines] = useState<Headline[]>([]);
@@ -134,7 +135,8 @@ export const RSSWidget = ({ onSendMessage }: RSSWidgetProps) => {
       const resp = await fetch(`https://api.allorigins.win/raw?url=${encodeURIComponent(currentHeadline.link)}`);
       const html = await resp.text();
       const text = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
-      const messageContent = `News article from ${currentHeadline.source} – ${currentHeadline.title}:\n\n${text}`;
+      const messageContent = `Summarize the following news article in detail and be ready to discuss it.\nSource: ${currentHeadline.source} – ${currentHeadline.title}\n\n${text}`;
+      onNewChat();
       onSendMessage(messageContent);
     } catch (err) {
       console.error('Failed to fetch article', err);

--- a/src/services/rssService.ts
+++ b/src/services/rssService.ts
@@ -1,0 +1,48 @@
+export interface Headline {
+  title: string;
+  link: string;
+  source?: string;
+}
+
+const DEFAULT_FEED = 'https://rss.cnn.com/rss/cnn_us.rss';
+
+export async function fetchRSSHeadlines(): Promise<Headline[]> {
+  const parser = new DOMParser();
+  const headlines: Headline[] = [];
+
+  const settings = JSON.parse(localStorage.getItem('vivica-settings') || '{}');
+  const feeds: string[] = settings.rssFeeds
+    ? settings.rssFeeds.split(',').map((s: string) => s.trim()).filter(Boolean)
+    : [DEFAULT_FEED];
+
+  for (const url of feeds) {
+    try {
+      const resp = await fetch(`https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`);
+      const data = await resp.text();
+      if (!data) continue;
+
+      const doc = parser.parseFromString(data, 'text/xml');
+      const items = doc.querySelectorAll('item');
+      const domain = new URL(url).hostname.replace('www.', '');
+
+      for (const item of items) {
+        const title = item.querySelector('title')?.textContent?.trim();
+        const link = item.querySelector('link')?.textContent?.trim();
+        if (title && link) {
+          headlines.push({ title, link, source: domain });
+        }
+      }
+    } catch (err) {
+      console.debug('Failed to fetch RSS feed:', url, err);
+      continue;
+    }
+  }
+
+  return headlines.slice(0, 10);
+}
+
+export async function fetchArticleText(url: string): Promise<string> {
+  const resp = await fetch(`https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`);
+  const html = await resp.text();
+  return html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+}


### PR DESCRIPTION
## Summary
- add `rssService` to fetch headlines and article text
- show RSS headlines in system prompt when enabled
- open new chat with detailed article summary request when headline clicked
- pass profile system prompt through new conversation

## Testing
- `npm run lint` *(fails: Unexpected any across repo)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6880f603df04832aaf3af54074febf8e