### PR TITLE
Use IndexedDB for memories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "cmdk": "^1.0.0",
         "date-fns": "^3.6.0",
         "embla-carousel-react": "^8.3.0",
+        "idb": "^7.1.1",
         "input-otp": "^1.2.4",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
@@ -7734,7 +7735,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ignore": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "cmdk": "^1.0.0",
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.3.0",
+    "idb": "^7.1.1",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",

--- a/src/components/VoiceAnimation.tsx
+++ b/src/components/VoiceAnimation.tsx
@@ -16,7 +16,7 @@ interface VoiceAnimationProps {
   isVisible: boolean;
   onClose: () => void;
   currentProfile: Record<string, unknown>;
-  getMemoryPrompt: () => string;
+  getMemoryPrompt: () => Promise<string>;
   buildSystemPrompt: () => Promise<string>;
   onSendMessage: (content: string) => void;
 }

--- a/src/js/db-utils.ts
+++ b/src/js/db-utils.ts
@@ -1,0 +1,125 @@
+import { openDB, DBSchema, IDBPDatabase } from 'idb';
+
+// IndexedDB schema for Vivica app
+interface VivicaDB extends DBSchema {
+  memories: {
+    key: string; // memory id
+    value: MemoryItem;
+    indexes: { 'by-profile': string };
+  };
+  memorySettings: {
+    key: string; // 'global' or profileId
+    value: MemoryData;
+  };
+  welcomeCache: {
+    key: number; // timestamp
+    value: { text: string; created: number };
+  };
+}
+
+export interface MemoryData {
+  scope: 'global' | 'profile';
+  profileId?: string;
+  identity: {
+    name: string;
+    pronouns: string;
+    occupation: string;
+    location: string;
+  };
+  personality: {
+    tone: string;
+    style: string;
+    interests: string;
+  };
+  customInstructions: string;
+  systemNotes: string;
+  tags: string;
+}
+
+export interface MemoryItem {
+  id: string;
+  content: string;
+  createdAt: string;
+  tags: string[];
+  scope: 'global' | 'profile';
+  profileId?: string;
+}
+
+let dbPromise: Promise<IDBPDatabase<VivicaDB>> | null = null;
+
+/**
+ * Initialize or retrieve the IndexedDB instance.
+ */
+export function getDB() {
+  if (!dbPromise) {
+    dbPromise = openDB<VivicaDB>('vivica-db', 1, {
+      upgrade(db) {
+        const store = db.createObjectStore('memories', { keyPath: 'id' });
+        store.createIndex('by-profile', 'profileId');
+        db.createObjectStore('memorySettings');
+        db.createObjectStore('welcomeCache');
+      }
+    });
+  }
+  return dbPromise;
+}
+
+/** Store or update memory settings by scope */
+export async function saveMemorySettings(key: string, value: MemoryData) {
+  const db = await getDB();
+  await db.put('memorySettings', value, key);
+}
+
+export async function loadMemorySettings(key: string) {
+  const db = await getDB();
+  return db.get('memorySettings', key);
+}
+
+/** Add a new memory entry */
+export async function addMemory(item: MemoryItem) {
+  const db = await getDB();
+  await db.put('memories', item);
+}
+
+/** Update an existing memory entry */
+export async function updateMemory(item: MemoryItem) {
+  const db = await getDB();
+  await db.put('memories', item);
+}
+
+/** Delete a memory entry by id */
+export async function deleteMemory(id: string) {
+  const db = await getDB();
+  await db.delete('memories', id);
+}
+
+/**
+ * Get memories. If a profileId is supplied, profile memories are included.
+ */
+export async function getMemories(profileId?: string) {
+  const db = await getDB();
+  const tx = db.transaction('memories');
+  const all = await tx.store.getAll();
+  return all.filter(m => m.scope === 'global' || m.profileId === profileId);
+}
+
+/** Cache a welcome message, keeping only the last 10 */
+export async function cacheWelcomeMessage(text: string) {
+  const db = await getDB();
+  const tx = db.transaction('welcomeCache', 'readwrite');
+  const now = Date.now();
+  await tx.store.put({ text, created: now }, now);
+  const keys = await tx.store.getAllKeys();
+  if (keys.length > 10) {
+    const excess = keys.sort().slice(0, keys.length - 10);
+    await Promise.all(excess.map(k => tx.store.delete(k)));
+  }
+  await tx.done;
+}
+
+export async function getWelcomeMessages() {
+  const db = await getDB();
+  const tx = db.transaction('welcomeCache');
+  const msgs = await tx.store.getAll();
+  return msgs.sort((a, b) => b.created - a.created).map(m => m.text);
+}


### PR DESCRIPTION
## Summary
- add IndexedDB helper with object stores for memories, memory settings and welcome cache
- refactor memory utilities to use IndexedDB
- update MemoryModal and Index page to load/save memory through IndexedDB
- expose memory editing and deletion in Index page
- adjust VoiceAnimation prop types

## Testing
- `npm run lint`
- `npx eslint src/pages/Index.tsx src/components/MemoryModal.tsx src/components/VoiceAnimation.tsx src/js/db-utils.ts src/utils/memoryUtils.ts`

------
https://chatgpt.com/codex/tasks/task_e_6880f6c3a590832ab2d3e3c0e99db2a1