### PR TITLE
Add message editing and regenerate options

### DIFF
--- a/src/components/ChatBody.tsx
+++ b/src/components/ChatBody.tsx
@@ -2,7 +2,7 @@
 import { forwardRef, useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { RotateCcw, Copy } from "lucide-react";
+import { RotateCcw, Copy, Pencil } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useTheme } from "@/hooks/useTheme";
 import { toast } from "sonner";
@@ -58,12 +58,14 @@ interface ChatBodyProps {
   conversation: Conversation | null;
   isTyping: boolean;
   onRetryMessage?: (messageId: string) => void;
+  onRegenerateMessage?: (messageId: string) => void;
+  onEditMessage?: (message: Message) => void;
   onSendMessage: (content: string) => void;
   onNewChat: () => void;
 }
 
 export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
-  ({ conversation, isTyping, onRetryMessage, onSendMessage, onNewChat }, ref) => {
+  ({ conversation, isTyping, onRetryMessage, onRegenerateMessage, onEditMessage, onSendMessage, onNewChat }, ref) => {
     const messagesEndRef = useRef<HTMLDivElement>(null);
     const { color, variant } = useTheme();
     const logoSrc = `/logo-${color}${variant}.png`;
@@ -193,7 +195,39 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
                         >
                           <Copy className="w-3 h-3" />
                         </Button>
-                        
+
+                        {message.role === 'user' && onEditMessage && (
+                          (() => {
+                            const lastIndex = conversation?.messages.length ? conversation.messages.length - 1 : -1;
+                            const isLastUser =
+                              (index === lastIndex && message.role === 'user') ||
+                              (index === lastIndex - 1 && conversation?.messages[lastIndex].role === 'assistant');
+                            return isLastUser ? (
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => onEditMessage(message)}
+                                className="h-6 w-6 p-0"
+                              >
+                                <Pencil className="w-3 h-3" />
+                              </Button>
+                            ) : null;
+                          })()
+                        )}
+
+                        {message.role === 'assistant' && onRegenerateMessage && (
+                          index === conversation?.messages.length - 1 ? (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => onRegenerateMessage(message.id)}
+                              className="h-6 w-6 p-0"
+                            >
+                              <RotateCcw className="w-3 h-3" />
+                            </Button>
+                          ) : null
+                        )}
+
                         {message.failed && onRetryMessage && (
                           <Button
                             variant="ghost"

--- a/src/components/ChatFooter.tsx
+++ b/src/components/ChatFooter.tsx
@@ -8,11 +8,19 @@ interface ChatFooterProps {
   onSendMessage: (message: string) => void;
   onVoiceToggle: () => void;
   isVoiceMode: boolean;
+  editingMessage?: string | null;
 }
 
-export const ChatFooter = ({ onSendMessage, onVoiceToggle, isVoiceMode }: ChatFooterProps) => {
+export const ChatFooter = ({ onSendMessage, onVoiceToggle, isVoiceMode, editingMessage }: ChatFooterProps) => {
   const [message, setMessage] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (editingMessage !== undefined) {
+      setMessage(editingMessage || "");
+      if (editingMessage) textareaRef.current?.focus();
+    }
+  }, [editingMessage]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -41,6 +49,9 @@ export const ChatFooter = ({ onSendMessage, onVoiceToggle, isVoiceMode }: ChatFo
   return (
     <footer className="border-t border-border bg-card/50 backdrop-blur-sm p-4">
       <div className="max-w-4xl mx-auto">
+        {editingMessage && (
+          <div className="text-xs text-muted-foreground mb-2">Editing previous message</div>
+        )}
         <form onSubmit={handleSubmit} className="flex items-end gap-3">
           {/* Voice Mode Button */}
           <Button


### PR DESCRIPTION
## Summary
- allow editing the last user message in ChatFooter
- add regenerate button for latest assistant response
- support editing/resend workflow in Index page

## Testing
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_e_6880fa397c44832a9e86b085a027c7e0