### PR TITLE
Improve chat bubble theming and icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.0",
+        "react-icons": "^4.11.0",
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^2.1.3",
         "react-router-dom": "^6.26.2",
@@ -10655,6 +10656,15 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
+      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-router-dom": "^6.26.2",
     "recharts": "^2.12.7",
     "remark-gfm": "^4.0.1",
+    "react-icons": "^4.11.0",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",

--- a/src/components/ChatBody.tsx
+++ b/src/components/ChatBody.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { RotateCcw, Copy, Pencil } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { FaUser, FaRobot } from "react-icons/fa";
 import { useTheme } from "@/hooks/useTheme";
 import { toast } from "sonner";
 import { WeatherWidget } from "@/components/WeatherWidget";
@@ -161,7 +162,8 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
               >
                 <div className="flex items-start gap-3 max-w-[85%] md:max-w-[70%]">
                   {message.role === 'assistant' && (
-                    <span className="mt-1 text-xs font-semibold text-accent-foreground">
+                    <span className="mt-1 flex items-center gap-1 text-xs font-semibold text-primary">
+                      <FaRobot className="w-3 h-3" />
                       {getProfileName(message.profileId)}
                     </span>
                   )}
@@ -169,7 +171,7 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
                   <div className={`message-bubble ${message.role} ${
                     message.failed ? 'border-accent/50 bg-accent/10' : ''
                   } ${message.isCodeResponse ? 'code-bubble' : ''}`}>
-                    <div className="prose prose-invert break-words max-w-none">
+                    <div className="prose dark:prose-invert break-words max-w-none">
                       <ReactMarkdown remarkPlugins={[remarkGfm]}>
                         {message.content}
                       </ReactMarkdown>
@@ -243,7 +245,8 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
                   </div>
                   
                   {message.role === 'user' && (
-                    <span className="mt-1 text-xs font-semibold text-muted-foreground">
+                    <span className="mt-1 flex items-center gap-1 text-xs font-semibold text-primary">
+                      <FaUser className="w-3 h-3" />
                       {getUserName()}
                     </span>
                   )}
@@ -255,7 +258,8 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
             {isTyping && (
               <div className="flex justify-start slide-up">
                 <div className="flex items-start gap-3">
-                  <span className="mt-1 text-xs font-semibold text-accent-foreground">
+                  <span className="mt-1 flex items-center gap-1 text-xs font-semibold text-primary">
+                    <FaRobot className="w-3 h-3" />
                     {getProfileName()}
                   </span>
                   <div className="message-bubble assistant">

--- a/src/index.css
+++ b/src/index.css
@@ -55,9 +55,9 @@
     --info: 180 100% 50%;
     --theme-primary: 0 0% 100%;
     --theme-accent: 0 0% 80%;
-    --user-bubble-bg: hsl(var(--accent) / 0.15);
-    --user-bubble-text: hsl(var(--accent-foreground));
-    --user-bubble-border: 1px solid hsl(var(--accent) / 0.4);
+    --user-bubble-bg: hsl(var(--primary));
+    --user-bubble-text: hsl(var(--primary-foreground));
+    --user-bubble-border: 1px solid hsl(var(--border-custom));
     --assistant-bubble-bg: hsl(var(--bg-secondary));
     --assistant-bubble-text: hsl(var(--text-primary));
     --assistant-bubble-border: 1px solid hsl(var(--border-custom));


### PR DESCRIPTION
## Summary
- tweak user bubble variables to use theme primary colors
- add FontAwesome icons and theme-aware name colors
- fix chat bubble text color switching with theme
- include react-icons dependency

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6880ff122fa4832a8f2d42dc02eab91d