### PR TITLE
Enhance voice orb states

### DIFF
--- a/src/components/VoiceAnimation.tsx
+++ b/src/components/VoiceAnimation.tsx
@@ -34,6 +34,13 @@ export const VoiceAnimation = ({
   const [voiceState, setVoiceState] = useState<VoiceState>('listening');
   const [unsupported] = useState(false);
 
+  const handleClose = () => {
+    voiceAnimation.setState('idle');
+    voiceAnimation.hide();
+    stopListening();
+    onClose();
+  };
+
   useEffect(() => {
     if (!isVisible) {
       voiceAnimation.hide();
@@ -110,7 +117,7 @@ export const VoiceAnimation = ({
     <div className="flex items-center justify-center h-full text-center text-white">
       <div>
         <p className="mb-4 text-lg">Voice mode is not supported on this device.</p>
-        <Button onClick={onClose}>Close</Button>
+        <Button onClick={handleClose}>Close</Button>
       </div>
     </div>
   ) : (
@@ -118,7 +125,7 @@ export const VoiceAnimation = ({
       <Button
         variant="ghost"
         size="icon"
-        onClick={onClose}
+        onClick={handleClose}
         className="absolute top-4 right-4 text-white hover:bg-white/20 z-10"
       >
         <X className="w-6 h-6" />

--- a/src/js/voice-animation.js
+++ b/src/js/voice-animation.js
@@ -10,6 +10,8 @@ class VoiceAnimation {
     this.currentMoodColor = '#00FF88';
     this.targetMoodColor = '#00FF88';
     this.pulseOffset = 0;
+    this.pulseSpeed = 0.03; // how fast the orb pulses
+    this.jitter = 0; // small random offset used while processing
     this.particles = [];
     this.isActive = false;
     
@@ -35,24 +37,7 @@ class VoiceAnimation {
       z-index: 1000;
       display: none;
     `;
-
-    // Create close button
-    const closeBtn = document.createElement('button');
-    closeBtn.innerHTML = '&times;';
-    closeBtn.style.cssText = `
-      position: absolute;
-      top: 20px;
-      right: 20px;
-      background: none;
-      border: none;
-      color: white;
-      font-size: 32px;
-      cursor: pointer;
-      z-index: 1001;
-    `;
-    closeBtn.addEventListener('click', () => this.hide());
-    
-    // Create canvas
+    // Create canvas for drawing the orb
     this.canvas = document.createElement('canvas');
     this.canvas.id = 'voice-canvas';
     this.canvas.style.cssText = `
@@ -63,7 +48,6 @@ class VoiceAnimation {
     `;
     
     this.animationContainer.appendChild(this.canvas);
-    this.animationContainer.appendChild(closeBtn);
     document.body.appendChild(this.animationContainer);
 
     this.ctx = this.canvas.getContext('2d');
@@ -85,27 +69,49 @@ class VoiceAnimation {
   }
 
   hide() {
+    // Fade to idle before fully hiding
+    this.setState('idle');
     this.animationContainer.style.display = 'none';
     this.isActive = false;
   }
 
   setState(state) {
+    const accent = this.getAccentColor();
     switch(state) {
+      case 'idle':
+        // Gray color and very slow pulse when idle
+        this.updateMood('#666666');
+        this.targetVolume = 0;
+        this.pulseSpeed = 0.01;
+        this.jitter = 0;
+        break;
       case 'listening':
-        this.updateMood('#00FF88');
+        // Calm blue/teal while listening
+        this.updateMood('#33ccff');
         this.targetVolume = 0.2;
+        this.pulseSpeed = 0.02;
+        this.jitter = 0;
         break;
       case 'processing':
-        this.updateMood('#FFD700');
+        // Gold and jittery fast pulse while processing
+        this.updateMood('#ffd700');
         this.targetVolume = 0.3;
+        this.pulseSpeed = 0.07;
+        this.jitter = 0.5;
         break;
       case 'speaking':
-        this.updateMood('#FF6B6B');
+        // Use theme accent (fallback magenta) when speaking
+        this.updateMood(accent || '#ff0077');
         this.targetVolume = 0.5;
+        this.pulseSpeed = 0.04;
+        this.jitter = 0;
         break;
       case 'error':
-        this.updateMood('#FF4444');
+        // Flash red when something goes wrong
+        this.updateMood('#ff4444');
         this.targetVolume = 0;
+        this.pulseSpeed = 0.03;
+        this.jitter = 0;
         setTimeout(() => this.setState('listening'), 3000);
         break;
     }
@@ -120,6 +126,13 @@ class VoiceAnimation {
     this.animationContainer.style.background = `radial-gradient(circle, ${color}22 0%, black 80%)`;
   }
 
+  // Get accent color from current theme if available
+  getAccentColor() {
+    const style = getComputedStyle(document.documentElement);
+    const val = style.getPropertyValue('--accent').trim() || style.getPropertyValue('--theme-accent').trim();
+    return val ? `hsl(${val})` : null;
+  }
+
   animate() {
     if (!this.isActive) {
       requestAnimationFrame(() => this.animate());
@@ -129,7 +142,7 @@ class VoiceAnimation {
     // Smooth transitions
     this.volume += (this.targetVolume - this.volume) * 0.1;
     this.currentMoodColor = this.lerpColor(this.currentMoodColor, this.targetMoodColor, 0.05);
-    this.pulseOffset += 0.03;
+    this.pulseOffset += this.pulseSpeed;
 
     this.drawOrb();
     requestAnimationFrame(() => this.animate());
@@ -140,8 +153,8 @@ class VoiceAnimation {
     
     const baseRadius = Math.min(this.canvas.width, this.canvas.height) * 0.15;
     const radius = baseRadius + this.volume * (baseRadius * 2) + Math.sin(this.pulseOffset) * (baseRadius * 0.2);
-    const x = this.canvas.width / 2;
-    const y = this.canvas.height / 2;
+    const x = this.canvas.width / 2 + (Math.random() - 0.5) * this.jitter * baseRadius;
+    const y = this.canvas.height / 2 + (Math.random() - 0.5) * this.jitter * baseRadius;
 
     // Outer glow
     const outerGlow = this.ctx.createRadialGradient(x, y, radius * 0.3, x, y, radius * 2.5);


### PR DESCRIPTION
## Summary
- expand `voiceAnimation` overlay to handle `idle` state and use theme accent colors
- tune pulse & jitter speeds for listening, processing and speaking
- drop extra close button on the canvas overlay
- make VoiceAnimation component end voice mode on close

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68810024b19c832a9a670ae7b4339af3