### PR TITLE
Fix object rendering in messages and memory

### DIFF
--- a/src/components/ChatBody.tsx
+++ b/src/components/ChatBody.tsx
@@ -185,7 +185,15 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
                   } ${message.isCodeResponse ? 'code-bubble' : ''}`}>
                     <div className="prose dark:prose-invert break-words max-w-none">
                       <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                        {message.content}
+                        {
+                          // Avoid rendering raw objects like [object Object]
+                          // If the message content isn't a string, log it and
+                          // fall back to JSON so the UI stays readable
+                          typeof message.content === 'string'
+                            ? message.content
+                            : (console.log('Non-string message', message.content),
+                              JSON.stringify(message.content))
+                        }
                       </ReactMarkdown>
                     </div>
                     
@@ -204,7 +212,13 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
                         <Button
                           variant="ghost"
                           size="sm"
-                          onClick={() => handleCopyMessage(message.content)}
+                          onClick={() =>
+                            handleCopyMessage(
+                              typeof message.content === 'string'
+                                ? message.content
+                                : JSON.stringify(message.content)
+                            )
+                          }
                           className="h-6 w-6 p-0"
                         >
                           <Copy className="w-3 h-3" />

--- a/src/components/MemoryModal.tsx
+++ b/src/components/MemoryModal.tsx
@@ -422,7 +422,15 @@ export const MemoryModal = ({
                   <div key={entry.id} className="p-3 bg-muted/10 rounded-lg border border-border">
                     <div className="flex justify-between items-start">
                       <div className="space-y-2">
-                        <div className="text-sm whitespace-pre-line">{entry.content}</div>
+                        <div className="text-sm whitespace-pre-line">
+                          {
+                            // Handle cases where content might be an object
+                            typeof entry.content === 'string'
+                              ? entry.content
+                              : (console.log('Non-string memory entry', entry.content),
+                                JSON.stringify(entry.content))
+                          }
+                        </div>
                         <div className="text-xs text-muted-foreground flex items-center gap-2">
                           <span className={`inline-block w-2 h-2 rounded-full ${
                             entry.scope === 'global' ? 'bg-blue-500' : 'bg-purple-500'


### PR DESCRIPTION
## Summary
- avoid rendering `[object Object]` in chat messages
- copy correct text from messages
- guard against non-string memory entries

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6881026a0750832abf55b4fa5976438e