### PR TITLE
Update chat bubble colors

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -58,8 +58,9 @@
     --user-bubble-bg: hsl(var(--primary));
     --user-bubble-text: hsl(var(--primary-foreground));
     --user-bubble-border: 1px solid hsl(var(--border-custom));
-    --assistant-bubble-bg: hsl(var(--bg-secondary));
-    --assistant-bubble-text: hsl(var(--text-primary));
+    /* Reverse colors for the assistant bubble */
+    --assistant-bubble-bg: hsl(var(--primary-foreground));
+    --assistant-bubble-text: hsl(var(--primary));
     --assistant-bubble-border: 1px solid hsl(var(--border-custom));
     --gradient-primary: linear-gradient(135deg, hsl(var(--bg-primary)) 0%, hsl(var(--bg-hover)) 100%);
     --gradient-accent: linear-gradient(135deg, hsl(var(--theme-primary)) 0%, hsl(var(--theme-accent)) 100%);


### PR DESCRIPTION
## Summary
- reverse user and assistant chat bubble colors so they're consistent with the active theme
- ensure timestamp display remains in message bubble

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688104e255f4832ab04c68455271f4e1