### PR TITLE
Always show conversation action button on mobile

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -189,7 +189,7 @@ export const Sidebar = ({
                           <Button
                             variant="ghost"
                             size="sm"
-                            className="opacity-0 group-hover:opacity-100 transition-opacity h-6 w-6 p-0"
+                            className="opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity h-6 w-6 p-0"
                             onClick={(e) => e.stopPropagation()}
                           >
                             <MoreVertical className="w-3 h-3" />


### PR DESCRIPTION
## Summary
- make the conversation options button visible by default on small screens

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688106808e40832aae9892a18dbc5cce