### PR TITLE
Audit notes for memory persistence

### DIFF
--- a/src/components/MemoryModal.tsx
+++ b/src/components/MemoryModal.tsx
@@ -75,11 +75,16 @@ export const MemoryModal = ({
   useEffect(() => {
     const savedMemory = localStorage.getItem('vivica-memory');
     const memoryActive = localStorage.getItem('vivica-memory-active');
-    
+
     if (savedMemory) {
       setMemory(JSON.parse(savedMemory));
     }
-    
+
+    // TODO(vivica-audit): support loading per-profile or global memory
+    // from the new keys (`vivica-memory-global` and
+    // `vivica-memory-profile-<id>`). Currently we only read the legacy
+    // `vivica-memory` key so per-profile memory is not restored on reload.
+
     if (memoryActive !== null) {
       setIsActive(JSON.parse(memoryActive));
     }
@@ -113,11 +118,14 @@ export const MemoryModal = ({
       profileId: memory.scope === 'profile' ? profileId : undefined
     };
 
-    const key = memory.scope === 'global' 
+    const key = memory.scope === 'global'
       ? 'vivica-memory-global'
       : `vivica-memory-profile-${profileId}`;
 
+    // Persist under the scoped key and the legacy `vivica-memory` key so
+    // other parts of the app continue to load the latest data.
     localStorage.setItem(key, JSON.stringify(saveMemory));
+    localStorage.setItem('vivica-memory', JSON.stringify(saveMemory));
     localStorage.setItem('vivica-memory-active', JSON.stringify(isActive));
     
     toast.success(`Memory saved (${memory.scope} scope)!`);
@@ -134,6 +142,8 @@ export const MemoryModal = ({
         tags: '',
       };
       setMemory(emptyMemory);
+      // TODO(vivica-audit): also clear persisted memory keys so stale data
+      // isn't loaded next time the app starts.
       toast.success("Memory data reset");
     }
   };

--- a/src/utils/memoryUtils.ts
+++ b/src/utils/memoryUtils.ts
@@ -16,6 +16,10 @@ interface MemoryItem {
   tags: string[];
 }
 
+// TODO(vivica-audit): these helpers write to IndexedDB but the main chat
+// system only loads memory from localStorage. Integrate DB reads when
+// building the conversation prompt so saved memories actually influence chats.
+
 /**
  * Saves a new memory item with scope control
  * @param content - Memory content text


### PR DESCRIPTION
## Summary
- note that memory modal only loads `vivica-memory` and doesn't read new scoped keys
- write legacy key on save and mention clearing memory on reset
- add TODO about hooking IndexedDB memories into chat prompts

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68810a07abc0832a87a7640f587897b1