### PR TITLE
Update code bubble styling

### DIFF
--- a/src/components/ChatBody.tsx
+++ b/src/components/ChatBody.tsx
@@ -147,6 +147,17 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
       });
     };
 
+    /**
+     * Determine if a message should be styled as code.
+     * Treat responses flagged as code or containing common
+     * code block markers as code messages.
+     */
+    const isCodeMessage = (msg: Message) => {
+      if (msg.isCodeResponse) return true;
+      const text = typeof msg.content === 'string' ? msg.content : '';
+      return /```|<code>|<pre>|\bconst\b|\bfunction\b/.test(text);
+    };
+
     return (
       <div
         ref={ref}
@@ -186,11 +197,11 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
                     </span>
                   )}
                   
-                  <div className={`message-bubble ${message.role} ${
-                    message.failed ? 'border-accent/50 bg-accent/10' : ''
-                  } ${message.isCodeResponse ? 'code-bubble' : ''}`}>
-                    {/* TODO(vivica-audit): add CSS for .code-bubble so code responses
-                        stand out from normal messages */}
+                  <div
+                    className={`message-bubble ${message.role} ${
+                      message.failed ? 'border-accent/50 bg-accent/10' : ''
+                    } ${isCodeMessage(message) ? 'code-bubble' : ''}`}
+                  >
                     <div className="prose dark:prose-invert break-words max-w-none">
                       <ReactMarkdown remarkPlugins={[remarkGfm]}>
                         {

--- a/src/index.css
+++ b/src/index.css
@@ -680,6 +680,15 @@
   border: var(--assistant-bubble-border);
 }
 
+/* Distinct styling for messages containing code */
+.code-bubble {
+  background: hsl(var(--bg-tertiary));
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+  border: 1px solid hsl(var(--border-custom));
+  box-shadow: 0 1px 4px hsl(var(--shadow));
+}
+
 /* Typing indicator */
 .typing-indicator {
   display: flex;


### PR DESCRIPTION
## Summary
- highlight code responses with new `.code-bubble` style
- auto-detect code snippets in messages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68815afdbd18832aac98af4d81ca65fe