### PR TITLE
Add default RSS feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
   - Up-to-the-minute local weather in the sidebar/welcome screen.
 
 - **Animated RSS News Ticker:**
-  - Scrolls through the latest headlines from your chosen (or default CNN US) RSS feed.
+  - Scrolls through the latest headlines from your chosen (or default ABC News) RSS feed.
   - Click a headline to inject it into chat—Vivica now fetches the full article via a CORS proxy,
     cleans it with the Readability algorithm, and then summarizes it with her usual flair.
 

--- a/src/components/RSSWidget.tsx
+++ b/src/components/RSSWidget.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { toast } from 'sonner';
 import { Loader2, ExternalLink } from 'lucide-react';
 import { fetchArticleText } from '@/services/rssService';
+import { DEFAULT_RSS_FEED } from '@/utils/constants';
 
 interface Headline {
   title: string;
@@ -12,7 +13,7 @@ interface Headline {
   source?: string;
 }
 
-const DEFAULT_FEED = 'https://rss.cnn.com/rss/cnn_us.rss';
+const DEFAULT_FEED = DEFAULT_RSS_FEED;
 
 // Fetch RSS feeds via a CORS proxy and return basic info for each item.
 async function fetchRSSSummariesWithLinks(urls: string[]): Promise<Headline[]> {

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -15,6 +15,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { toast } from "sonner";
 import { ThemeSelector } from "./ThemeSelector";
 import { ApiKeyInput } from "./ApiKeyInput";
+import { DEFAULT_RSS_FEED } from "@/utils/constants";
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -27,7 +28,7 @@ export const SettingsModal = ({ isOpen, onClose }: SettingsModalProps) => {
     apiKey2: '',
     apiKey3: '',
     braveApiKey: localStorage.getItem('braveApiKey') || '',
-    rssFeeds: '',
+    rssFeeds: DEFAULT_RSS_FEED,
     includeWeather: false,
     includeRss: false,
   });

--- a/src/services/rssService.ts
+++ b/src/services/rssService.ts
@@ -1,5 +1,6 @@
 // Readability gives us a clean article body from messy HTML pages.
 import { Readability } from '@mozilla/readability';
+import { DEFAULT_RSS_FEED } from '@/utils/constants';
 
 export interface Headline {
   title: string;
@@ -8,7 +9,7 @@ export interface Headline {
   source?: string;
 }
 
-const DEFAULT_FEED = 'https://rss.cnn.com/rss/cnn_us.rss';
+const DEFAULT_FEED = DEFAULT_RSS_FEED;
 
 export async function fetchRSSHeadlines(): Promise<Headline[]> {
   const parser = new DOMParser();

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_RSS_FEED = 'https://abcnews.go.com/abcnews/topstories';


### PR DESCRIPTION
## Summary
- define `DEFAULT_RSS_FEED` constant with ABC News top stories URL
- use this default for RSS widget and RSS service
- prefill RSS feed field in settings with that value
- update README to mention ABC News as the default feed

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68815fbf6988832aa87cfbd1ae2b6ce3