### PR TITLE
Update message bubble prose styling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -680,6 +680,24 @@
   border: var(--assistant-bubble-border);
 }
 
+.message-bubble .prose {
+  --tw-prose-body: currentColor;
+  --tw-prose-headings: currentColor;
+  --tw-prose-lead: currentColor;
+  --tw-prose-links: currentColor;
+  --tw-prose-bold: currentColor;
+  --tw-prose-counters: currentColor;
+  --tw-prose-bullets: currentColor;
+  --tw-prose-hr: currentColor;
+  --tw-prose-quotes: currentColor;
+  --tw-prose-quote-borders: currentColor;
+  --tw-prose-code: currentColor;
+  --tw-prose-pre-code: currentColor;
+  --tw-prose-pre-bg: transparent;
+  --tw-prose-th-borders: currentColor;
+  --tw-prose-td-borders: currentColor;
+}
+
 /* Distinct styling for messages containing code */
 .code-bubble {
   background: hsl(var(--bg-tertiary));


### PR DESCRIPTION
## Summary
- theme color overrides for `.message-bubble .prose`
- rebuild

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68816720703c832a9c0dd623bbd94b6b