### PR TITLE
Update sidebar logo and remove header icon

### DIFF
--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -31,13 +31,12 @@ export const ChatHeader = ({
   onOpenProfiles,
   onSaveSummary
 }: ChatHeaderProps) => {
-  const { color, variant, setVariant } = useTheme();
+  const { variant, setVariant } = useTheme();
 
   const toggleVariant = () => {
     setVariant(variant === 'dark' ? 'light' : 'dark');
   };
 
-  const logoSrc = `/logo-${color}${variant}.png`;
   return (
     <div className="flex items-center justify-between p-4 border-b border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/60">
       <div className="flex items-center gap-3">
@@ -49,8 +48,6 @@ export const ChatHeader = ({
         >
           <Menu className="w-5 h-5" />
         </Button>
-
-        <img src={logoSrc} alt="Vivica" className="h-8 w-8" />
 
         <div className="flex items-center gap-3">
           <ProfileSwitcher

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { X, Plus, Search, User, Brain, Settings, MoreVertical, Edit2, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { useTheme } from "@/hooks/useTheme";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -62,6 +63,9 @@ export const Sidebar = ({
   const [renamingConversation, setRenamingConversation] = useState<Conversation | null>(null);
   const [newTitle, setNewTitle] = useState("");
 
+  const { color, variant } = useTheme();
+  const logoSrc = `/logo-${color}${variant}.png`;
+
   const filteredConversations = conversations.filter(conv =>
     conv.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
     conv.lastMessage?.toLowerCase().includes(searchTerm.toLowerCase())
@@ -116,9 +120,7 @@ export const Sidebar = ({
           <div className="p-4 border-b border-border">
             <div className="flex items-center justify-between mb-4">
               <div className="flex items-center gap-2">
-                <div className="w-8 h-8 rounded-full bg-accent text-accent-foreground flex items-center justify-center font-bold">
-                  V
-                </div>
+                <img src={logoSrc} alt="Vivica" className="w-8 h-8" />
                 <span className="font-semibold">Vivica</span>
               </div>
               <Button


### PR DESCRIPTION
## Summary
- show theme-aware logo in the sidebar header
- drop logo from the chat header

## Testing
- `npm run lint` *(fails: cannot load `@typescript-eslint/no-unused-expressions`)*

------
https://chatgpt.com/codex/tasks/task_e_688173154c90832a946db08d77f52c26