### PR TITLE
Move regenerate title button to sidebar

### DIFF
--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -22,8 +22,6 @@ interface ChatHeaderProps {
   onProfileChange: (profile: Profile) => void;
   onOpenProfiles: () => void;
   onSaveSummary: () => void;
-  /** Manually regenerate the conversation title */
-  onGenerateTitle: () => void;
 }
 
 export const ChatHeader = ({
@@ -32,7 +30,6 @@ export const ChatHeader = ({
   onProfileChange,
   onOpenProfiles,
   onSaveSummary,
-  onGenerateTitle
 }: ChatHeaderProps) => {
   const { variant, setVariant } = useTheme();
 
@@ -71,15 +68,6 @@ export const ChatHeader = ({
           title="Save & Summarize conversation"
         >
           <Bookmark className="w-4 h-4" />
-        </Button>
-        {/* Generate a witty title for this chat */}
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={onGenerateTitle}
-          title="Regenerate title"
-        >
-          <Sparkles className="w-4 h-4" />
         </Button>
         <Button variant="ghost" size="icon" onClick={toggleVariant}>
           {variant === 'dark' ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -128,14 +128,27 @@ export const Sidebar = ({
                 <img src={logoSrc} alt="Vivica" className="w-8 h-8" />
                 <span className="font-semibold">Vivica</span>
               </div>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={onClose}
-                className="md:hidden"
-              >
-                <X className="w-4 h-4" />
-              </Button>
+              <div className="flex items-center gap-1">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  title="Regenerate title"
+                  disabled={!currentConversation}
+                  onClick={() =>
+                    currentConversation && onGenerateTitle(currentConversation)
+                  }
+                >
+                  <Sparkles className="w-4 h-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={onClose}
+                  className="md:hidden"
+                >
+                  <X className="w-4 h-4" />
+                </Button>
+              </div>
             </div>
             
             <Button

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -798,7 +798,6 @@ const Index = () => {
           onProfileChange={handleProfileChange}
           onOpenProfiles={() => setShowProfiles(true)}
           onSaveSummary={handleSaveSummary}
-          onGenerateTitle={() => handleGenerateTitle(currentConversation || undefined)}
         />
         
         <ChatBody


### PR DESCRIPTION
## Summary
- move `Regenerate Title` button from chat header to sidebar header
- update component props and usage

## Testing
- `npm run lint` *(fails: Error while loading rule `@typescript-eslint/no-unused-expressions`)*

------
https://chatgpt.com/codex/tasks/task_e_688178af567c832ab340c04a47305f74