### PR TITLE
Remove typing indicator

### DIFF
--- a/src/components/ChatBody.tsx
+++ b/src/components/ChatBody.tsx
@@ -300,25 +300,6 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
               </div>
             ))}
 
-            {/* Typing indicator */}
-            {isTyping && (
-              <div className="flex justify-start slide-up">
-                <div className="flex items-start gap-3">
-                  <span className="mt-1 flex items-center gap-1 text-xs font-semibold text-primary">
-                    <FaRobot className="w-3 h-3" />
-                    {getProfileName()}
-                  </span>
-                  <div className="message-bubble assistant">
-                    <div className="typing-indicator">
-                      <div className="typing-dot"></div>
-                      <div className="typing-dot"></div>
-                      <div className="typing-dot"></div>
-                      <span className="ml-2">{getProfileName()} is typing...</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            )}
 
             <div ref={messagesEndRef} />
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -707,27 +707,3 @@
   box-shadow: 0 1px 4px hsl(var(--shadow));
 }
 
-/* Typing indicator */
-.typing-indicator {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 16px;
-  color: hsl(var(--text-muted));
-}
-
-.typing-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: hsl(var(--accent-primary));
-  animation: typingDot 1.4s infinite;
-}
-
-.typing-dot:nth-child(2) { animation-delay: 0.2s; }
-.typing-dot:nth-child(3) { animation-delay: 0.4s; }
-
-@keyframes typingDot {
-  0%, 60%, 100% { opacity: 0.3; }
-  30% { opacity: 1; }
-}


### PR DESCRIPTION
## Summary
- remove typing indicator markup from ChatBody
- drop typing indicator CSS

## Testing
- `npm run lint` *(fails: cannot read property 'allowShortCircuit')*

------
https://chatgpt.com/codex/tasks/task_e_688187c46cc8832ab66ab84c032f157c