### PR TITLE
Add smooth scroll-to-bottom button

### DIFF
--- a/src/components/ChatBody.tsx
+++ b/src/components/ChatBody.tsx
@@ -162,7 +162,7 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
     return (
       <div
         ref={ref}
-        className="flex-1 overflow-y-auto p-4 space-y-6"
+        className="flex-1 overflow-y-auto p-4 space-y-6 relative"
       >
         {!conversation?.messages.length ? (
           // Empty state

--- a/src/components/ScrollToBottomButton.tsx
+++ b/src/components/ScrollToBottomButton.tsx
@@ -1,0 +1,24 @@
+import { ArrowDown } from "lucide-react";
+
+interface ScrollToBottomButtonProps {
+  /** Whether the button should be visible */
+  visible: boolean;
+  /** Called when the user clicks the button */
+  onClick: () => void;
+}
+
+/**
+ * Floating button shown when the chat is scrolled up.
+ * Clicking it smoothly scrolls to the latest message.
+ */
+export const ScrollToBottomButton = ({ visible, onClick }: ScrollToBottomButtonProps) => {
+  return (
+    <button
+      aria-label="Scroll to latest message"
+      onClick={onClick}
+      className={`absolute right-4 bottom-24 z-10 p-2 rounded-full bg-accent text-accent-foreground shadow transition-opacity duration-300 ${visible ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+    >
+      <ArrowDown className="w-5 h-5" />
+    </button>
+  );
+};


### PR DESCRIPTION
## Summary
- add floating scroll-to-bottom button component
- make ChatBody container relative
- handle scroll button visibility in Index page
- render button above chat footer

## Testing
- `npm run lint` *(fails: Error while loading rule `@typescript-eslint/no-unused-expressions`)*

------
https://chatgpt.com/codex/tasks/task_e_68818b267e68832ab76ca605d000284d