### PR TITLE
Fix voice mode restart

### DIFF
--- a/src/components/VoiceAnimation.tsx
+++ b/src/components/VoiceAnimation.tsx
@@ -6,10 +6,11 @@ import { Button } from "@/components/ui/button";
 import { voiceAnimation } from "@/js/voice-animation";
 import { 
   initVoiceMode, 
-  startListening, 
-  stopListening, 
+  startListening,
+  stopListening,
   getIsListening,
-  updateVoiceModeConfig 
+  updateVoiceModeConfig,
+  setVoiceModeActive
 } from "@/js/voice-mode";
 
 interface VoiceAnimationProps {
@@ -38,6 +39,7 @@ export const VoiceAnimation = ({
     voiceAnimation.setState('idle');
     voiceAnimation.hide();
     stopListening();
+    setVoiceModeActive(false);
     onClose();
   };
 

--- a/src/js/voice-mode.js
+++ b/src/js/voice-mode.js
@@ -61,6 +61,10 @@ let silenceTimer; // Timer to detect prolonged silence
 const SILENCE_TIMEOUT = 3000; // 3 seconds of silence to stop recognition
 let handledSpeech = false; // Flag to track if we've processed speech already
 
+// Track whether the overall voice mode UI is active. Used to
+// determine if recognition should auto-restart when it ends.
+let voiceModeActive = false;
+
 // Audio visualization variables
 let audioCtx = null;
 let analyser = null;
@@ -103,6 +107,16 @@ export function setProcessingState(state) {
 export function setCurrentConversationId(id) {
     vivicaVoiceModeConfig.conversationId = id;
     debugLog('Current conversation ID set to:', id);
+}
+
+// Track whether the voice mode interface is active
+export function setVoiceModeActive(active) {
+    voiceModeActive = active;
+    debugLog('Voice mode active:', active);
+}
+
+export function getVoiceModeActive() {
+    return voiceModeActive;
 }
 
 /**

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -14,6 +14,7 @@ import { searchBrave } from "@/services/searchService";
 import { Storage } from "@/utils/storage";
 import { fetchRSSHeadlines } from "@/services/rssService";
 import { getMemories, saveConversationMemory } from "@/utils/memoryUtils";
+import { setVoiceModeActive } from "@/js/voice-mode";
 
 function weatherCodeToText(code: number): string {
   const map: Record<number, string> = {
@@ -671,8 +672,10 @@ const Index = () => {
 
 
   const handleVoiceToggle = () => {
-    setIsVoiceMode(!isVoiceMode);
-    if (!isVoiceMode) {
+    const newState = !isVoiceMode;
+    setIsVoiceMode(newState);
+    setVoiceModeActive(newState);
+    if (newState) {
       setShowVoiceAnimation(true);
       toast.success("Voice mode activated");
     } else {
@@ -870,6 +873,7 @@ const Index = () => {
           onClose={() => {
             setShowVoiceAnimation(false);
             setIsVoiceMode(false);
+            setVoiceModeActive(false);
           }}
           currentProfile={currentProfile}
           getMemoryPrompt={getMemoryPrompt}


### PR DESCRIPTION
## Summary
- prevent undefined `voiceModeActive` errors
- allow UI to toggle voice mode state
- stop restarting recognition when the voice modal is closed

## Testing
- `npm install`
- `npm run lint` *(fails: Error while loading rule `@typescript-eslint/no-unused-expressions`)*

------
https://chatgpt.com/codex/tasks/task_e_688192d30368832a8dc8ad7f5e8297cc