### PR TITLE
Use icons for memory actions

### DIFF
--- a/src/components/MemoryModal.tsx
+++ b/src/components/MemoryModal.tsx
@@ -1,6 +1,7 @@
 
 import { useState, useEffect } from "react";
 import { Brain, Save, RotateCcw, FileDown, FileUp } from "lucide-react";
+import { FaEdit, FaTrash } from "react-icons/fa";
 import {
   Dialog,
   DialogContent,
@@ -464,7 +465,7 @@ export const MemoryModal = ({
                           size="xs"
                           onClick={() => handleEdit(entry)}
                         >
-                          Edit
+                          <FaEdit className="w-4 h-4" />
                         </Button>
                         <Button
                           variant="ghost"
@@ -472,7 +473,7 @@ export const MemoryModal = ({
                           className="text-destructive hover:text-destructive"
                           onClick={() => handleDelete({ id: entry.id })}
                         >
-                          Delete
+                          <FaTrash className="w-4 h-4" />
                         </Button>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- swap out Edit/Delete text for FontAwesome icons in memory modal

## Testing
- `npm run lint` *(fails: Cannot read properties of undefined (reading 'allowShortCircuit'))*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6881938d59f8832a806f2d36746d8ef5