### PR TITLE
Relax memory summary length limit

### DIFF
--- a/src/utils/memoryUtils.ts
+++ b/src/utils/memoryUtils.ts
@@ -105,7 +105,8 @@ export async function saveConversationMemory(
     : "This is a global memory - keep it broadly applicable to all personas.";
 
   const messageCount = messages.length;
-  const charLimit = messageCount < 10 ? 150 : messageCount <= 30 ? 300 : 600;
+  // Allow more generous memory summaries based on conversation length
+  const charLimit = messageCount < 10 ? 250 : messageCount <= 30 ? 500 : 1000;
 
   const prompt = `
   As Vivica, create a ${scope} memory from this conversation.


### PR DESCRIPTION
## Summary
- allow longer generated summaries in `saveConversationMemory`

## Testing
- `npm run lint` *(fails: cannot read properties of undefined)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688198aafbf8832ab549e8c41570d5f1