### PR TITLE
Add floating scroll to bottom button

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@
   - Installable on desktop and mobile.
   - Works offline, full data persistence, fast loading.
 
-- **Modern UI & Theme System:**  
+- **Modern UI & Theme System:**
   - Multiple color themes, dark/light toggle (with advanced dark themes for AMOLED screens).
   - Clean, focused layout designed for both desktop and mobile use.
+  - Floating "scroll to bottom" button appears when new messages arrive while you're reading earlier chat history.
 
 ---
 

--- a/src/components/ChatBody.tsx
+++ b/src/components/ChatBody.tsx
@@ -84,8 +84,14 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
       messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
     };
 
+    // Auto-scroll only when the user is already near the bottom. This allows
+    // scrolling up to read older messages without being snapped back down.
     useEffect(() => {
-      scrollToBottom();
+      const el = (ref as React.RefObject<HTMLDivElement>)?.current;
+      if (!el) return;
+      const atBottom =
+        el.scrollHeight - el.scrollTop <= el.clientHeight + 20;
+      if (atBottom) scrollToBottom();
     }, [conversation?.messages, isTyping]);
 
     // Fetch a dynamic welcome message from the LLM whenever the welcome screen appears

--- a/src/components/ScrollToBottomButton.tsx
+++ b/src/components/ScrollToBottomButton.tsx
@@ -8,8 +8,9 @@ interface ScrollToBottomButtonProps {
 }
 
 /**
- * Floating button shown when the chat is scrolled up.
- * Clicking it smoothly scrolls to the latest message.
+ * Floating button shown when the chat is scrolled up and new messages arrive.
+ * It fades in/out using Tailwind transitions and never intercepts clicks when
+ * hidden. Clicking it smoothly scrolls to the latest message.
  */
 export const ScrollToBottomButton = ({ visible, onClick }: ScrollToBottomButtonProps) => {
   return (

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -560,10 +560,16 @@ const Index = () => {
           return { ...conv, messages: msgs, lastMessage: fullContent, timestamp: new Date() };
         }));
 
-        chatBodyRef.current?.scrollTo({
-          top: chatBodyRef.current.scrollHeight,
-          behavior: 'smooth'
-        });
+        if (chatBodyRef.current) {
+          // Keep auto-scrolling while streaming only if the user is already
+          // near the bottom. Otherwise, show the scroll-to-bottom button.
+          const el = chatBodyRef.current;
+          const atBottom =
+            el.scrollHeight - el.scrollTop <= el.clientHeight + 20;
+          if (atBottom) {
+            el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+          }
+        }
       }
 
       // Conversation finished streaming; attempt auto-title if needed


### PR DESCRIPTION
## Summary
- only auto-scroll when already near the bottom
- keep stream auto-scroll near bottom only
- document scroll button behaviour and update README

## Testing
- `npm run lint` *(fails: Cannot read properties of undefined (reading 'allowShortCircuit'))*

------
https://chatgpt.com/codex/tasks/task_e_6881974d8c4c832a96180217be2d58f2