### PR TITLE
Improve code highlighting in chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@
 - **Modern UI & Theme System:**
   - Multiple color themes, dark/light toggle (with advanced dark themes for AMOLED screens).
   - Clean, focused layout designed for both desktop and mobile use.
-  - Floating "scroll to bottom" button appears when new messages arrive while you're reading earlier chat history.
+- Floating "scroll to bottom" button appears when new messages arrive while you're reading earlier chat history.
+- **Improved Code Blocks:**
+  - Code snippets now have Prism-based syntax highlighting, a dark background, and a copy-to-clipboard button.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "input-otp": "^1.2.4",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
+        "prismjs": "^1.30.0",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
@@ -10584,6 +10585,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "input-otp": "^1.2.4",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",
+    "prismjs": "^1.30.0",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",

--- a/src/components/ChatBody.tsx
+++ b/src/components/ChatBody.tsx
@@ -3,6 +3,7 @@ import { forwardRef, useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { RotateCcw, Copy, Pencil } from "lucide-react";
+import { CodeBlock } from "./CodeBlock";
 import { Button } from "@/components/ui/button";
 import { FaUser, FaRobot } from "react-icons/fa";
 import { useTheme } from "@/hooks/useTheme";
@@ -154,16 +155,6 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
       });
     };
 
-    /**
-     * Determine if a message should be styled as code.
-     * Treat responses flagged as code or containing common
-     * code block markers as code messages.
-     */
-    const isCodeMessage = (msg: Message) => {
-      if (msg.isCodeResponse) return true;
-      const text = typeof msg.content === 'string' ? msg.content : '';
-      return /```|<code>|<pre>|\bconst\b|\bfunction\b/.test(text);
-    };
 
     return (
       <div
@@ -207,10 +198,24 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
                   <div
                     className={`message-bubble ${message.role} ${
                       message.failed ? 'border-accent/50 bg-accent/10' : ''
-                    } ${isCodeMessage(message) ? 'code-bubble' : ''}`}
+                    }`}
                   >
                     <div className="prose dark:prose-invert break-words max-w-none">
-                      <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                      <ReactMarkdown
+                        remarkPlugins={[remarkGfm]}
+                        components={{
+                          code({ node, inline, className, children, ...props }) {
+                            if (inline) {
+                              return (
+                                <code className="inline-code" {...props}>{children}</code>
+                              );
+                            }
+                            return (
+                              <CodeBlock className={className}>{children}</CodeBlock>
+                            );
+                          }
+                        }}
+                      >
                         {
                           // Avoid rendering raw objects like [object Object]
                           // If the message content isn't a string, log it and

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,0 +1,52 @@
+// Custom code block renderer for chat messages
+// Highlights code with Prism and provides a copy button
+import { useEffect, useRef, useState } from 'react';
+import Prism from 'prismjs';
+import 'prismjs/components/prism-javascript';
+import 'prismjs/components/prism-jsx';
+import 'prismjs/components/prism-typescript';
+import 'prismjs/components/prism-tsx';
+import 'prismjs/components/prism-python';
+import 'prismjs/components/prism-bash';
+import 'prismjs/components/prism-json';
+import { Copy, Check } from 'lucide-react';
+
+interface CodeBlockProps {
+  className?: string;
+  children: React.ReactNode;
+}
+
+export function CodeBlock({ className, children }: CodeBlockProps) {
+  const codeRef = useRef<HTMLElement>(null);
+  const [copied, setCopied] = useState(false);
+  const language = className?.replace('language-', '') || '';
+  const code = String(children).trim();
+
+  useEffect(() => {
+    if (codeRef.current) {
+      Prism.highlightElement(codeRef.current);
+    }
+  }, [code]);
+
+  // Copy raw code to clipboard and show feedback
+  const handleCopy = () => {
+    navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <div className="code-block-container group">
+      <button
+        onClick={handleCopy}
+        className="copy-btn"
+        aria-label="Copy code"
+      >
+        {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+      </button>
+      <pre className="code-block">
+        <code ref={codeRef} className={`language-${language}`}>{code}</code>
+      </pre>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,5 @@
 
+@import 'prismjs/themes/prism-tomorrow.css';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -705,5 +706,54 @@
     "Liberation Mono", "Courier New", monospace;
   border: 1px solid hsl(var(--border-custom));
   box-shadow: 0 1px 4px hsl(var(--shadow));
+}
+
+/* Inline code styling */
+.inline-code {
+  background: #24292f;
+  color: #f6f8fa;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  padding: 0.125rem 0.25rem;
+  border-radius: 0.25rem;
+}
+
+/* Code block container and copy button */
+.code-block-container {
+  position: relative;
+}
+
+.copy-btn {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  background: transparent;
+  color: #d0d0d0;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.code-block-container:hover .copy-btn {
+  opacity: 1;
+}
+
+@media (max-width: 768px) {
+  .copy-btn {
+    opacity: 1;
+  }
+}
+
+.code-block {
+  background: #24292f;
+  color: #f6f8fa;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  padding: 0.75rem;
+  border-radius: 0.375rem;
+  overflow-x: auto;
 }
 


### PR DESCRIPTION
## Summary
- add Prism.js dependency
- render code blocks with new `CodeBlock` component
- style code and inline snippets with dark theme
- document improved code handling in README

## Testing
- `npm run build:dev`

------
https://chatgpt.com/codex/tasks/task_e_6881dbffdeec832a9255a055558cfcb8