### PR TITLE
Improve scroll-to-bottom button

### DIFF
--- a/src/components/ChatBody.tsx
+++ b/src/components/ChatBody.tsx
@@ -91,7 +91,7 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
       const el = (ref as React.RefObject<HTMLDivElement>)?.current;
       if (!el) return;
       const atBottom =
-        el.scrollHeight - el.scrollTop <= el.clientHeight + 20;
+        el.scrollHeight - el.scrollTop <= el.clientHeight + 16;
       if (atBottom) scrollToBottom();
     }, [conversation?.messages, isTyping]);
 

--- a/src/components/ScrollToBottomButton.tsx
+++ b/src/components/ScrollToBottomButton.tsx
@@ -17,7 +17,7 @@ export const ScrollToBottomButton = ({ visible, onClick }: ScrollToBottomButtonP
     <button
       aria-label="Scroll to latest message"
       onClick={onClick}
-      className={`absolute right-4 bottom-24 z-10 p-2 rounded-full bg-accent text-accent-foreground shadow transition-opacity duration-300 ${visible ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+      className={`absolute right-4 bottom-24 z-10 p-2 rounded-full bg-background/70 text-foreground shadow-md hover:bg-background/90 transition-opacity duration-300 ${visible ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
     >
       <ArrowDown className="w-5 h-5" />
     </button>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -117,8 +117,8 @@ const Index = () => {
     if (!el) return;
     const onScroll = () => {
       const atBottom =
-        el.scrollHeight - el.scrollTop <= el.clientHeight + 20;
-      if (atBottom) setShowScrollButton(false);
+        el.scrollHeight - el.scrollTop <= el.clientHeight + 16;
+      setShowScrollButton(!atBottom);
     };
     el.addEventListener('scroll', onScroll);
     return () => el.removeEventListener('scroll', onScroll);
@@ -129,8 +129,8 @@ const Index = () => {
     const el = chatBodyRef.current;
     if (!el) return;
     const atBottom =
-      el.scrollHeight - el.scrollTop <= el.clientHeight + 20;
-    if (!atBottom) setShowScrollButton(true);
+      el.scrollHeight - el.scrollTop <= el.clientHeight + 16;
+    setShowScrollButton(!atBottom);
   }, [currentConversation?.messages.length, isTyping]);
 
   // Hide the button when switching conversations
@@ -565,7 +565,7 @@ const Index = () => {
           // near the bottom. Otherwise, show the scroll-to-bottom button.
           const el = chatBodyRef.current;
           const atBottom =
-            el.scrollHeight - el.scrollTop <= el.clientHeight + 20;
+            el.scrollHeight - el.scrollTop <= el.clientHeight + 16;
           if (atBottom) {
             el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
           }


### PR DESCRIPTION
## Summary
- adjust scroll detection logic to show the button whenever not at bottom
- lower scroll threshold from 20px to 16px
- lighten the floating button style

## Testing
- `npm run lint` *(fails: cannot read properties of undefined in @typescript-eslint/no-unused-expressions)*

------
https://chatgpt.com/codex/tasks/task_e_6882096d4fc4832a8b3d864793a4297b