### PR TITLE
Improve button loading feedback

### DIFF
--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -1,5 +1,6 @@
 
-import { Menu, Sun, Moon, Bookmark, Sparkles } from "lucide-react";
+import { Menu, Sun, Moon, Bookmark, Sparkles, Loader2 } from "lucide-react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { ProfileSwitcher } from "./ProfileSwitcher";
 import { useTheme } from "@/hooks/useTheme";
@@ -32,6 +33,17 @@ export const ChatHeader = ({
   onSaveSummary,
 }: ChatHeaderProps) => {
   const { variant, setVariant } = useTheme();
+  const [saving, setSaving] = useState(false);
+
+  const handleSaveClick = async () => {
+    if (saving) return;
+    setSaving(true);
+    try {
+      await onSaveSummary();
+    } finally {
+      setSaving(false);
+    }
+  };
 
   const toggleVariant = () => {
     setVariant(variant === 'dark' ? 'light' : 'dark');
@@ -64,10 +76,16 @@ export const ChatHeader = ({
         <Button
           variant="ghost"
           size="icon"
-          onClick={onSaveSummary}
+          onClick={handleSaveClick}
           title="Save & Summarize conversation"
+          disabled={saving}
+          aria-busy={saving}
         >
-          <Bookmark className="w-4 h-4" />
+          {saving ? (
+            <Loader2 className="w-4 h-4 animate-spin text-accent" />
+          ) : (
+            <Bookmark className="w-4 h-4" />
+          )}
         </Button>
         <Button variant="ghost" size="icon" onClick={toggleVariant}>
           {variant === 'dark' ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}

--- a/src/components/RSSWidget.tsx
+++ b/src/components/RSSWidget.tsx
@@ -69,6 +69,7 @@ export const RSSWidget = ({ onSendMessage, onNewChat }: RSSWidgetProps) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [opacity, setOpacity] = useState(1);
+  const [injecting, setInjecting] = useState(false);
 
   useEffect(() => {
     const loadRSSFeeds = async () => {
@@ -143,6 +144,9 @@ export const RSSWidget = ({ onSendMessage, onNewChat }: RSSWidgetProps) => {
       return;
     }
 
+    if (injecting) return;
+    setInjecting(true);
+
     try {
       const article = await fetchArticleText(currentHeadline.link);
       const content = article || currentHeadline.description || '';
@@ -166,6 +170,9 @@ export const RSSWidget = ({ onSendMessage, onNewChat }: RSSWidgetProps) => {
       onSendMessage(messageContent);
       toast.error('Failed to load full article, using summary.');
     }
+    finally {
+      setInjecting(false);
+    }
   };
 
   return (
@@ -173,13 +180,21 @@ export const RSSWidget = ({ onSendMessage, onNewChat }: RSSWidgetProps) => {
       <div className="text-sm transition-opacity duration-300" style={{ opacity }}>
         <Button
           variant="ghost"
-          className="w-full h-auto p-0 text-foreground hover:text-accent justify-start gap-2"
+          className="w-full h-auto p-0 text-foreground hover:text-accent justify-start gap-2 relative"
           onClick={handleHeadlineClick}
+          disabled={injecting}
+          aria-busy={injecting}
         >
-          <span className="shrink-0">📰</span>
-          <span className="truncate text-left">{currentHeadline.title}</span>
-          {currentHeadline.link.startsWith('http') && (
-            <ExternalLink className="w-3 h-3 opacity-0 group-hover:opacity-70 ml-auto" />
+          {injecting ? (
+            <Loader2 className="w-4 h-4 animate-spin text-accent" />
+          ) : (
+            <>
+              <span className="shrink-0">📰</span>
+              <span className="truncate text-left">{currentHeadline.title}</span>
+              {currentHeadline.link.startsWith('http') && (
+                <ExternalLink className="w-3 h-3 opacity-0 group-hover:opacity-70 ml-auto" />
+              )}
+            </>
           )}
         </Button>
       </div>


### PR DESCRIPTION
## Summary
- add Loader2 spinner to Save & Summarize action
- disable the button while saving
- show loading indicator when injecting RSS headlines

## Testing
- `npm install`
- `npm run lint` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68820c8285dc832a8abe6b227f51a1be