### PR TITLE
Improve voice mode conversation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@
   - Choose your own AI model for each profile.
   - Assign a specialized coder model (like `qwen/qwen-2.5-coder-32b-instruct:free`) for programming questions, with seamless handoff to Vivica for human-style delivery.
 
-- **Voice Mode (with Custom Animation):**  
+- **Voice Mode (with Custom Animation):**
   - Beautiful orb animation for speech recognition and text-to-speech.
   - VoiceMode is responsive, visually dynamic, and designed to *feel* like a real companion—not just a boring mic button.
+  - After Vivica speaks, listening automatically resumes so conversations flow naturally.
 
 - **Memory System (Knowledge Base):**  
   - **Global memory**: persistent knowledge shared by all profiles.

--- a/src/js/voice-mode.js
+++ b/src/js/voice-mode.js
@@ -496,7 +496,10 @@ export function speak(text) {
             vivicaVoiceModeConfig.onListenStateChange('idle');
             setProcessingState(false);
             resolve();
-            // Listening will only restart if the user clicks start again
+            if (voiceModeActive) {
+                debugLog('Restarting listening after speech end');
+                startListening();
+            }
         };
 
         currentSpeechUtterance.onerror = (event) => {


### PR DESCRIPTION
## Summary
- automatically start listening again after Vivica finishes speaking
- document smoother voice mode flow in README

## Testing
- `npm install`
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*

------
https://chatgpt.com/codex/tasks/task_e_688297698174832aa8b13dceba0fac2f